### PR TITLE
aio IP defaults to ansible_default_ipv4

### DIFF
--- a/roles/configure_aio_server/defaults/main.yml
+++ b/roles/configure_aio_server/defaults/main.yml
@@ -17,7 +17,7 @@ aio_configuration_manufacturing_disable_key_storage_filesystem: false
 aio_configuration_manufacturing_disable_key_storage_tpm: false
 aio_configuration_manufacturing_use_secp256r1: false
 aio_configuration_contact_hostname: ~
-aio_configuration_contact_addresses_IpAddr: "{{ ansible_eth0.ipv4.address }}" # Must be either set manually or used with `gather_facts: true` in your playbook. Also note that some newer versions of Linux don't support `eth0` interface.
+aio_configuration_contact_addresses_IpAddr: "{{ ansible_default_ipv4.address }}" # Must be either set manually (if you system has more than one interface) or used with `gather_facts: true` in your playbook.
 #aio_configuration_serviceinfo_api_auth_token: TestAuthToken # change to a valid API token
 #aio_configuration_serviceinfo_api_admin_token: TestAdminToken # change to a valid API token
 

--- a/roles/configure_aio_server/meta/argument_specs.yml
+++ b/roles/configure_aio_server/meta/argument_specs.yml
@@ -83,9 +83,9 @@ argument_specs:
         default: ~
       aio_configuration_contact_addresses_IpAddr:
         description:
-          - IP Address of the host machine. Must be either set manually or used with `gather_facts true` in your playbook. Also note that some newer versions of Linux don't support `eth0` interface. 
+          - IP Address of the host machine. Must be either set manually (if you system has more than one interface) or used with `gather_facts true` in your playbook.
         type: str
-        default: "{{ ansible_eth0.ipv4.address }}"
+        default: "{{ ansible_default_ipv4.address }}"
       aio_configuration_serviceinfo_api_auth_token:
         description:
           - Serviceinfo api authorization token. Change to a valid API token. 


### PR DESCRIPTION
##### SUMMARY
FDO must be used in RHEL 8 or 9, where we don't find "eth0" interfaces anymore by default. 

Using `ansible_eth0.ipv4.address` makes the playbook run to fail while using `ansible_default_ipv4.address` will make it work by default when the system has one interface (usual if using VMs)
