### PR TITLE
Fix serviceinfo template

### DIFF
--- a/roles/configure_owner_server/templates/serviceinfo-api-server.yml.j2
+++ b/roles/configure_owner_server/templates/serviceinfo-api-server.yml.j2
@@ -1,24 +1,24 @@
 ---
 service_info:
-  initial_user: 
+  initial_user:
     username: {{ serviceinfo_api_server_service_info_initial_user_username }}
-    {% if serviceinfo_api_server_service_info_initial_user_password is not none %}   
+{% if serviceinfo_api_server_service_info_initial_user_password is not none %}
     password: {{ serviceinfo_api_server_service_info_initial_user_password }}
-    {% endif %}
-    {% if serviceinfo_api_server_service_info_initial_user_sshkeys is not none %}   
+{% endif %}
+{% if serviceinfo_api_server_service_info_initial_user_sshkeys is not none %}
     sshkeys:
     - {{ serviceinfo_api_server_service_info_initial_user_sshkeys }}
-    {% endif %}
+{% endif %}
   files:
   - path: {{ serviceinfo_api_server_service_files_path }}
     source_path: {{ serviceinfo_api_server_service_files_source_path }}
-  commands: 
+  commands:
   - command: touch
     args:
     - {{ serviceinfo_api_server_test_path }}
     return_stdout: true
     return_stderr: true
-  diskencryption_clevis: 
+  diskencryption_clevis:
   - disk_label: {{ serviceinfo_api_server_diskencryption_clevis_disk_label }}
     binding:
       pin: tpm2


### PR DESCRIPTION
##### SUMMARY
This PR fixes an issue with the serviceinfo-api configuration template that makes it produce a YAML with incorrect indentation. It in turn causes the serviceinfo-api server to fail to start. The problem manifests itself regardless of whether an SSH key is provided or the default is used.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
roles/configure_owner_server

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
Run a playbook with the `configure_owner_server` includes. The `fdo-serviceinfo-api` service will fail to start.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
# systemctl status fdo-serviceinfo-api-server
× fdo-serviceinfo-api-server.service - FDO service info API server
     Loaded: loaded (/usr/lib/systemd/system/fdo-serviceinfo-api-server.service; enabled; vendor preset: disabled)
     Active: failed (Result: exit-code) since Thu 2023-02-09 13:38:30 IST; 19s ago
    Process: 2725 ExecStart=/usr/libexec/fdo/fdo-serviceinfo-api-server (code=exited, status=1/FAILURE)
   Main PID: 2725 (code=exited, status=1/FAILURE)
        CPU: 3ms

Feb 09 13:38:30 rhel9 systemd[1]: Started FDO service info API server.
Feb 09 13:38:30 rhel9 fdo-serviceinfo-api-server[2725]: Error: Loading configuration file from /etc/fdo
Feb 09 13:38:30 rhel9 fdo-serviceinfo-api-server[2725]: Caused by:
Feb 09 13:38:30 rhel9 fdo-serviceinfo-api-server[2725]:     mapping values are not allowed in this context at line 5 column 17 in etc/fdo/serviceinfo-api-server.yml
Feb 09 13:38:30 rhel9 systemd[1]: fdo-serviceinfo-api-server.service: Main process exited, code=exited, status=1/FAILURE
Feb 09 13:38:30 rhel9 systemd[1]: fdo-serviceinfo-api-server.service: Failed with result 'exit-code'.
```
