### PR TITLE
Fix type of dependencies list in galaxy meta

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,12 +9,12 @@ description: FDO components installation and configuration
 license:
   - GPL-3.0-or-later
 license_file: LICENSE
-tags: 
+tags:
   - fdo
   - fido
   - device_onboarding
-dependencies: 
-  - ansible.posix: '*'
+dependencies:
+  ansible.posix: '*'
 repository: https://github.com/ansible-collections/community.fdo
 documentation: https://github.com/ansible-collections/community.fdo/blob/main/examples/README.md
 homepage: https://github.com/ansible-collections/community.fdo


### PR DESCRIPTION
##### SUMMARY
This PR fixes the type of dependencies list in galaxy.yml. 
With the wrong type Ansible tools fail to process the file.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
galaxy.xml

##### ADDITIONAL INFORMATION
The wrong type results in the following error when running, for instance, `ansible-lint`

```paste below
WARNING  Retrying execution failure 250 of: ansible-galaxy collection install -vvv --force -p /home/me/.cache/ansible-compat/0d07ea/collections .
ERROR    Command returned 250 code:
ansible-galaxy [core 2.14.0]
  config file = None
  configured module search path = ['/home/me/.cache/ansible-compat/0d07ea/modules', '/home/me/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/me/.local/lib/python3.10/site-packages/ansible
  ansible collection location = /home/me/.cache/ansible-compat/0d07ea/collections:/home/me/.ansible/collections:/usr/share/ansible/collections
  executable location = /home/me/.local/bin/ansible-galaxy
  python version = 3.10.10 (main, Feb  8 2023, 00:00:00) [GCC 12.2.1 20221121 (Red Hat 12.2.1-4)] (/usr/local/bin/python)
  jinja version = 3.0.3
  libyaml = True
No config file found; using defaults
Starting galaxy collection install process
Found installed collection community.fdo:0.0.1 at '/home/me/.cache/ansible-compat/0d07ea/collections/ansible_collections/community/fdo'
Process install dependency map
the full traceback was:

Traceback (most recent call last):
  File "/home/me/.local/lib/python3.10/site-packages/ansible/cli/__init__.py", line 647, in cli_executor
    exit_code = cli.run()
  File "/home/me/.local/lib/python3.10/site-packages/ansible/cli/galaxy.py", line 681, in run
    return context.CLIARGS['func']()
  File "/home/me/.local/lib/python3.10/site-packages/ansible/cli/galaxy.py", line 116, in method_wrapper
    return wrapped_method(*args, **kwargs)
  File "/home/me/.local/lib/python3.10/site-packages/ansible/cli/galaxy.py", line 1344, in execute_install
    self._execute_install_collection(
  File "/home/me/.local/lib/python3.10/site-packages/ansible/cli/galaxy.py", line 1381, in _execute_install_collection
    install_collections(
  File "/home/me/.local/lib/python3.10/site-packages/ansible/galaxy/collection/__init__.py", line 730, in install_collections
    dependency_map = _resolve_depenency_map(
  File "/home/me/.local/lib/python3.10/site-packages/ansible/galaxy/collection/__init__.py", line 1777, in _resolve_depenency_map
    return collection_dep_resolver.resolve(
  File "/home/me/.local/lib/python3.10/site-packages/resolvelib/resolvers.py", line 453, in resolve
    state = resolution.resolve(requirements, max_rounds=max_rounds)
  File "/home/me/.local/lib/python3.10/site-packages/resolvelib/resolvers.py", line 347, in resolve
    failure_causes = self._attempt_to_pin_criterion(name, criterion)
  File "/home/me/.local/lib/python3.10/site-packages/resolvelib/resolvers.py", line 207, in _attempt_to_pin_criterion
    criteria = self._get_criteria_to_update(candidate)
  File "/home/me/.local/lib/python3.10/site-packages/resolvelib/resolvers.py", line 198, in _get_criteria_to_update
    for r in self._p.get_dependencies(candidate):
  File "/home/me/.local/lib/python3.10/site-packages/ansible/galaxy/dependency_resolution/providers.py", line 498, in get_dependencies
    for dep_name, dep_req in req_map.items()
AttributeError: 'list' object has no attribute 'items'
```
