### PR TITLE
Run ansible-lint on example playbooks

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -10,3 +10,8 @@ jobs:
       uses: ansible/ansible-lint-action@v6
       with:
         path: "./roles"
+    - name: Lint Sample Playbooks
+      uses: ansible/ansible-lint-action@v6
+      with:
+        path: "./playbooks"
+

--- a/playbooks/configure_aio_server.yml
+++ b/playbooks/configure_aio_server.yml
@@ -7,8 +7,9 @@
   become: true
   gather_facts: true
   vars:
-    - aio_configuration_serviceinfo_api_auth_token: "demo-token-77622c4b-c057-4295-950a-87bd951a3dda"
-    - aio_configuration_serviceinfo_api_admin_token: "demo-token-48a7bea0-6989-4304-8957-eae0a754647b"
+    aio_configuration_serviceinfo_api_auth_token: "demo-token-77622c4b-c057-4295-950a-87bd951a3dda"
+    aio_configuration_serviceinfo_api_admin_token: "demo-token-48a7bea0-6989-4304-8957-eae0a754647b"
   tasks:
-    - ansible.builtin.include_role:
+    - name: Configure all-in-one server
+      ansible.builtin.include_role:
         name: community.fdo.configure_aio_server

--- a/playbooks/configure_servers.yml
+++ b/playbooks/configure_servers.yml
@@ -7,7 +7,8 @@
   become: true
   gather_facts: true
   tasks:
-    - ansible.builtin.include_role:
+    - name: Configure Manufacturing Server
+      ansible.builtin.include_role:
         name: community.fdo.configure_manufacturing_server
 
 - name: Configure FDO Owner Server
@@ -15,9 +16,10 @@
   become: true
   gather_facts: true
   vars:
-    - update_keys_certs: false
+    update_keys_certs: false
   tasks:
-    - ansible.builtin.include_role:
+    - name: Configure Owner Server
+      ansible.builtin.include_role:
         name: community.fdo.configure_owner_server
 
 - name: Configure FDO Rendezvous Server
@@ -25,7 +27,8 @@
   become: true
   gather_facts: true
   vars:
-    - update_cert: false
+    update_cert: false
   tasks:
-    - ansible.builtin.include_role:
+    - name: Configure Rendezvous Server
+      ansible.builtin.include_role:
         name: community.fdo.configure_rendezvous_server

--- a/playbooks/copy_manufacturing_server_certs_to_owner_server.yml
+++ b/playbooks/copy_manufacturing_server_certs_to_owner_server.yml
@@ -7,5 +7,6 @@
   become: true
   gather_facts: true
   tasks:
-    - ansible.builtin.include_role:
+    - name: Copy certificates to owner server
+      ansible.builtin.include_role:
         name: community.fdo.copy_manufacturing_server_certs_to_owner_server

--- a/playbooks/copy_manufacturing_server_certs_to_rendezvous_server.yml
+++ b/playbooks/copy_manufacturing_server_certs_to_rendezvous_server.yml
@@ -7,5 +7,6 @@
   become: true
   gather_facts: true
   tasks:
-    - ansible.builtin.include_role:
+    - name: Copy certificates fro rendezvous server
+      ansible.builtin.include_role:
         name: community.fdo.copy_manufacturing_server_certs_to_rendezvous_server

--- a/playbooks/copy_ownership_vouchers.yml
+++ b/playbooks/copy_ownership_vouchers.yml
@@ -7,5 +7,6 @@
   become: true
   gather_facts: true
   tasks:
-    - ansible.builtin.include_role:
+    - name: Copy ownership vouchers (OV) from manufacturer to owner
+      ansible.builtin.include_role:
         name: community.fdo.copy_ownership_vouchers

--- a/playbooks/fetch_manufacturing_server_certs_to_localhost.yml
+++ b/playbooks/fetch_manufacturing_server_certs_to_localhost.yml
@@ -7,5 +7,6 @@
   become: true
   gather_facts: true
   tasks:
-    - ansible.builtin.include_role:
+    - name: Copy certificates from manufacturing to local host
+      ansible.builtin.include_role:
         name: community.fdo.fetch_manufacturing_server_certs_to_localhost

--- a/playbooks/provision_aio_server.yml
+++ b/playbooks/provision_aio_server.yml
@@ -7,5 +7,6 @@
   become: true
   gather_facts: true
   tasks:
-    - ansible.builtin.include_role:
+    - name: Set up all-on-one server
+      ansible.builtin.include_role:
         name: community.fdo.setup_aio_server

--- a/playbooks/provision_servers.yml
+++ b/playbooks/provision_servers.yml
@@ -7,7 +7,8 @@
   become: true
   gather_facts: true
   tasks:
-    - ansible.builtin.include_role:
+    - name: Set up manaufacturing server
+      ansible.builtin.include_role:
         name: community.fdo.setup_manufacturing_server
 
 - name: Provision FDO Owner Server
@@ -15,9 +16,10 @@
   become: true
   gather_facts: true
   vars:
-    - copy_manufacturer_certs: false
+    copy_manufacturer_certs: false
   tasks:
-    - ansible.builtin.include_role:
+    - name: Set up owner server
+      ansible.builtin.include_role:
         name: community.fdo.setup_owner_server
 
 - name: Provision FDO Rendezvous Server
@@ -25,7 +27,8 @@
   become: true
   gather_facts: true
   vars:
-    - copy_manufacturer_certs: false
+    copy_manufacturer_certs: false
   tasks:
-    - ansible.builtin.include_role:
+    - name: Set up rendezvous sever
+      ansible.builtin.include_role:
         name: community.fdo.setup_rendezvous_server


### PR DESCRIPTION
##### SUMMARY
This PR adds a GitHub job that will run ansbile-lint on the example playbooks - in addition to the roles, and fixes all existing lint rule violations in those playbooks.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
playbooks

##### ADDITIONAL INFORMATION

```
Run ansible/ansible-lint-action@v6
  with:
    path: ./playbooks

< ... redacted for brevity ... >

Passed with production profile: 0 failure(s), 0 warning(s) on 9 files.
```