### PR TITLE
Add support for Simple Content Access (SCA) subscriptions

### DIFF
--- a/roles/check_rhel_subscription/tasks/main.yml
+++ b/roles/check_rhel_subscription/tasks/main.yml
@@ -11,4 +11,6 @@
 - name: RHEL Subscription
   ansible.builtin.fail:
     msg: RHEL Subscription not available.
-  when: '"Overall Status: Current" not in subscription_status.stdout'
+  when:
+    - '"Overall Status: Current" not in subscription_status.stdout'
+    - '"Content Access Mode is set to Simple Content Access" not in subscription_status.stdout'


### PR DESCRIPTION
##### SUMMARY
Fixes #21

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
roles/check_rhel_subscription

##### ADDITIONAL INFORMATION
The role ran successfully on a RHEL 9.1 system with a SCA subscription, notice the `Overall Status: Disabled`

```console
# subscription-manager status
Overall Status: Disabled
Content Access Mode is set to Simple Content Access. This host has access to content, regardless of subscription status.
```