### PR TITLE
Skip checking for a valid RHEL subscription on non-RHEL systems

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,8 @@ Other changes
 - Replaced the `systemctl status` command with `ansible.builtin.systemd` module for checking the status of a systemd service
 - Added `changed_when` to commands for indicating when a command causes changes
 - Used `present` instead of `latest` for packages to avoid inadvertent upgrades
+- Added support for Simple Content Access (SCA) subscriptions on RHEL
+- Allowed running the roles on non-RHEL systems that include the FDO packages
 
 v1.0.0
 ======

--- a/roles/check_rhel_subscription/tasks/main.yml
+++ b/roles/check_rhel_subscription/tasks/main.yml
@@ -2,15 +2,25 @@
 # Copyright: (c) 2022, XLAB Steampunk <steampunk@xlab.si>
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Check RHEL Subscription
-  ansible.builtin.command: subscription-manager status
-  register: subscription_status
-  ignore_errors: true
-  changed_when: false # changes nothing
+- name: Gather operating system if needed
+  ansible.builtin.setup:
+    gather_subset:
+      - "distribution"
+      - "!min"
+  when: ansible_facts.distribution is not defined
 
-- name: RHEL Subscription
-  ansible.builtin.fail:
-    msg: RHEL Subscription not available.
-  when:
-    - '"Overall Status: Current" not in subscription_status.stdout'
-    - '"Content Access Mode is set to Simple Content Access" not in subscription_status.stdout'
+- name: Check for a valid subscription RHEL systems
+  when: ansible_facts.distribution == "RedHat"
+  block:
+    - name: Check RHEL Subscription
+      ansible.builtin.command: subscription-manager status
+      register: subscription_status
+      ignore_errors: true
+      changed_when: false # changes nothing
+
+    - name: RHEL Subscription
+      ansible.builtin.fail:
+        msg: RHEL Subscription not available.
+      when:
+        - '"Overall Status: Current" not in subscription_status.stdout'
+        - '"Content Access Mode is set to Simple Content Access" not in subscription_status.stdout'

--- a/roles/setup_aio_server/meta/main.yml
+++ b/roles/setup_aio_server/meta/main.yml
@@ -1,0 +1,6 @@
+---
+# Copyright: (c) 2023, Red Hat
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+dependencies:
+  - role: check_rhel_subscription

--- a/roles/setup_aio_server/meta/main.yml
+++ b/roles/setup_aio_server/meta/main.yml
@@ -2,5 +2,14 @@
 # Copyright: (c) 2023, Red Hat
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+galaxy_info:
+  description: Setup FDO AIO Server
+  author: XLAB Steampunk <steampunk@xlab.si>
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.9"
+  platforms:
+    - name: Fedora
+      version: all
+
 dependencies:
   - role: check_rhel_subscription

--- a/roles/setup_aio_server/tasks/main.yaml
+++ b/roles/setup_aio_server/tasks/main.yaml
@@ -2,10 +2,6 @@
 # Copyright: (c) 2022, XLAB Steampunk <steampunk@xlab.si>
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Check Subscription
-  ansible.builtin.import_role:
-    name: check_rhel_subscription
-
 - name: Install Packages
   ansible.builtin.dnf:
     state: present

--- a/roles/setup_manufacturing_server/meta/main.yml
+++ b/roles/setup_manufacturing_server/meta/main.yml
@@ -1,0 +1,6 @@
+---
+# Copyright: (c) 2023, Red Hat
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+dependencies:
+  - role: check_rhel_subscription

--- a/roles/setup_manufacturing_server/meta/main.yml
+++ b/roles/setup_manufacturing_server/meta/main.yml
@@ -2,5 +2,14 @@
 # Copyright: (c) 2023, Red Hat
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+galaxy_info:
+  description: Setup FDO Manufacturing Server
+  author: XLAB Steampunk <steampunk@xlab.si>
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.9"
+  platforms:
+    - name: Fedora
+      version: all
+
 dependencies:
   - role: check_rhel_subscription

--- a/roles/setup_manufacturing_server/tasks/main.yaml
+++ b/roles/setup_manufacturing_server/tasks/main.yaml
@@ -2,10 +2,6 @@
 # Copyright: (c) 2022, XLAB Steampunk <steampunk@xlab.si>
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Check Subscription
-  ansible.builtin.import_role:
-    name: check_rhel_subscription
-
 - name: Install Packages
   ansible.builtin.dnf:
     state: present

--- a/roles/setup_owner_server/meta/main.yml
+++ b/roles/setup_owner_server/meta/main.yml
@@ -2,5 +2,14 @@
 # Copyright: (c) 2023, Red Hat
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+galaxy_info:
+  description: Setup FDO Owner Server
+  author: XLAB Steampunk <steampunk@xlab.si>
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.9"
+  platforms:
+    - name: Fedora
+      version: all
+
 dependencies:
   - role: check_rhel_subscription

--- a/roles/setup_owner_server/meta/main.yml
+++ b/roles/setup_owner_server/meta/main.yml
@@ -1,0 +1,6 @@
+---
+# Copyright: (c) 2023, Red Hat
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+dependencies:
+  - role: check_rhel_subscription

--- a/roles/setup_owner_server/tasks/main.yaml
+++ b/roles/setup_owner_server/tasks/main.yaml
@@ -2,10 +2,6 @@
 # Copyright: (c) 2022, XLAB Steampunk <steampunk@xlab.si>
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Check Subscription
-  ansible.builtin.import_role:
-    name: check_rhel_subscription
-
 - name: Install Packages
   ansible.builtin.dnf:
     state: present

--- a/roles/setup_rendezvous_server/meta/argument_specs.yml
+++ b/roles/setup_rendezvous_server/meta/argument_specs.yml
@@ -5,7 +5,7 @@
 argument_specs:
   main:
     version_added: 1.0.0
-    short_description: Setup the owner server
+    short_description: Setup the rendezvous server
     description:
       - Checks RHEL subscription and installs fdo-rendezvous-server package with dnf.
         Creates FDO keys directory, copies manufacturer certificate from manufacturing server and creates rendezvous service keys stores.

--- a/roles/setup_rendezvous_server/meta/main.yml
+++ b/roles/setup_rendezvous_server/meta/main.yml
@@ -1,0 +1,6 @@
+---
+# Copyright: (c) 2023, Red Hat
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+dependencies:
+  - role: check_rhel_subscription

--- a/roles/setup_rendezvous_server/meta/main.yml
+++ b/roles/setup_rendezvous_server/meta/main.yml
@@ -2,5 +2,14 @@
 # Copyright: (c) 2023, Red Hat
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+galaxy_info:
+  description: Setup FDO Rendezvous Server
+  author: XLAB Steampunk <steampunk@xlab.si>
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.9"
+  platforms:
+    - name: Fedora
+      version: all
+
 dependencies:
   - role: check_rhel_subscription

--- a/roles/setup_rendezvous_server/tasks/main.yaml
+++ b/roles/setup_rendezvous_server/tasks/main.yaml
@@ -2,10 +2,6 @@
 # Copyright: (c) 2022, XLAB Steampunk <steampunk@xlab.si>
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Check Subscription
-  ansible.builtin.import_role:
-    name: check_rhel_subscription
-
 - name: Install Packages
   ansible.builtin.dnf:
     state: present


### PR DESCRIPTION
##### SUMMARY

Fixes #15.

Also, optimizes the check when multiple FDO services are installed on the same host (e.g. rendezvous + owner).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
roles/check_rhel_subscription
roles/setup_aio_server
roles/setup_manufacturing_server
roles/setup_owner_server
roles/setup_rendezvous_server

##### ADDITIONAL INFORMATION

On RHEL with a valid subscription:
```paste below
TASK [community.fdo.check_rhel_subscription : Validating arguments against arg spec 'main' - Check RHEL subscription] ****************************************************************************
ok: [manufacturing]

TASK [community.fdo.check_rhel_subscription : Gather operating system if needed] *****************************************************************************************************************
skipping: [manufacturing]

TASK [community.fdo.check_rhel_subscription : Check RHEL Subscription] ***************************************************************************************************************************
ok: [manufacturing]

TASK [community.fdo.check_rhel_subscription : RHEL Subscription] *********************************************************************************************************************************
skipping: [manufacturing]
```

On RHEL without a valid subscription:
```
TASK [community.fdo.check_rhel_subscription : Validating arguments against arg spec 'main' - Check RHEL subscription] ****************************************************************************
ok: [manufacturing]

TASK [community.fdo.check_rhel_subscription : Gather operating system if needed] *****************************************************************************************************************
skipping: [manufacturing]

TASK [community.fdo.check_rhel_subscription : Check RHEL Subscription] ***************************************************************************************************************************
fatal: [manufacturing]: FAILED! => {"changed": false, "cmd": ["subscription-manager", "status"], "delta": "0:00:01.131769", "end": "2023-03-08 18:16:22.012453", "msg": "non-zero return code", "rc": 1, "start": "2023-03-08 18:16:20.880684", "stderr": "", "stderr_lines": [], "stdout": "+-------------------------------------------+\n   System Status Details\n+-------------------------------------------+\nOverall Status: Unknown\n\nSystem Purpose Status: Unknown", "stdout_lines": ["+-------------------------------------------+", "   System Status Details", "+-------------------------------------------+", "Overall Status: Unknown", "", "System Purpose Status: Unknown"]}
...ignoring

TASK [community.fdo.check_rhel_subscription : RHEL Subscription] *********************************************************************************************************************************
fatal: [manufacturing]: FAILED! => {"changed": false, "msg": "RHEL Subscription not available."}
```

On Rocky Linux:
```
TASK [community.fdo.check_rhel_subscription : Validating arguments against arg spec 'main' - Check RHEL subscription] ****************************************************************************
ok: [manufacturing]

TASK [community.fdo.check_rhel_subscription : Gather operating system if needed] *****************************************************************************************************************
skipping: [manufacturing]

TASK [community.fdo.check_rhel_subscription : Check RHEL Subscription] ***************************************************************************************************************************
skipping: [manufacturing]

TASK [community.fdo.check_rhel_subscription : RHEL Subscription] *********************************************************************************************************************************
skipping: [manufacturing]
```

Also, manual tests show that the role runs three times when installing each server on a separate host (manufacturing+owner+rendezvous), and only twice when the same host is used for rendezvous and owner.
