### PR TITLE
Add support for custom serviceinfo-api config

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,7 @@ Other changes
 - Added support for Simple Content Access (SCA) subscriptions on RHEL
 - Allowed running the roles on non-RHEL systems that include the FDO packages
 - Enabled a user to generate FDO keys and certificates locally and use them or custom ones with FDO servers
+- Made the ServiceInfo API sequence fully customizable
 
 v1.0.0
 ======

--- a/roles/configure_owner_server/meta/argument_specs.yml
+++ b/roles/configure_owner_server/meta/argument_specs.yml
@@ -94,27 +94,27 @@ argument_specs:
         default: true
       serviceinfo_api_server_service_info_initial_user_username:
         description:
-          - Username of the initial user of the serviceinfo api.
+          - Deprecated, use serviceinfo_api_server_config instead. Username of the initial user of the serviceinfo api.
         type: str
         default: admin
       serviceinfo_api_server_service_info_initial_user_password:
         description:
-          - Password of the initial user of the serviceinfo api.
+          - Deprecated, use serviceinfo_api_server_config instead. Password of the initial user of the serviceinfo api.
         type: str
         default: admin
       serviceinfo_api_server_service_info_initial_user_sshkeys:
         description:
-          - SSH Keys of the initial user of the serviceinfo api.
+          - Deprecated, use serviceinfo_api_server_config instead. SSH Keys of the initial user of the serviceinfo api.
         type: str
         default: ""
       serviceinfo_api_server_service_files_path:
         description:
-          - Serviceinfo api server service files path.
+          - Deprecated, use serviceinfo_api_server_config instead. Serviceinfo api server service files path.
         type: str
         default: /root/resolv.conf
       serviceinfo_api_server_service_files_source_path:
         description:
-          - Serviceinfo api server service files source path.
+          - Deprecated, use serviceinfo_api_server_config instead. Serviceinfo api server service files source path.
         type: str
         default: /etc/resolv.conf
       serviceinfo_api_server_bind_ip:
@@ -129,12 +129,12 @@ argument_specs:
         default: "{{ owner_onboarding_server_listen_port_serviceinfo_api_server}}"
       serviceinfo_api_server_test_path:
         description:
-          - Test directory path.
+          - Deprecated, use serviceinfo_api_server_config instead. Test directory path.
         type: str
         default: /root/test
       serviceinfo_api_server_diskencryption_clevis_disk_label:
         description:
-          - ...
+          - Deprecated, use serviceinfo_api_server_config instead.
         type: str
         default: /dev/vda4
       serviceinfo_api_server_device_specific_store_driver_path:
@@ -152,3 +152,9 @@ argument_specs:
           - Serviceinfo api admin authorization token. Change to a valid API token.
         type: str
         default: TestAdminToken
+      serviceinfo_api_server_config:
+        description:
+          - Serviceinfo api sequence in YAML format with 2-spaces indentation. If defined and not empty, this configuration will override all other
+            initial_user, files, commands, diskencryption_clevis, and additional_serviceinfo settings.
+        type: str
+        required: false

--- a/roles/configure_owner_server/templates/serviceinfo-api-server.yml.j2
+++ b/roles/configure_owner_server/templates/serviceinfo-api-server.yml.j2
@@ -1,5 +1,8 @@
 ---
 service_info:
+{% if serviceinfo_api_server_config is defined and serviceinfo_api_server_config is not none %}
+  {{ serviceinfo_api_server_config | indent(width=2) }}
+{% else %}
   initial_user:
     username: {{ serviceinfo_api_server_service_info_initial_user_username }}
 {% if serviceinfo_api_server_service_info_initial_user_password is not none %}
@@ -25,6 +28,7 @@ service_info:
       config: "{}"
     reencrypt: true
   additional_serviceinfo: ~
+{% endif %}
 bind: "{{ serviceinfo_api_server_bind_ip }}:{{ serviceinfo_api_server_listen_port_serviceinfo_api_server }}"
 device_specific_store_driver:
   Directory:


### PR DESCRIPTION
##### SUMMARY
Fixes #24

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
roles/configure_owner_server

##### ADDITIONAL INFORMATION
A new variable has been added for a custom serviceinfo-api sequence. If the new variable is not set, the old limited configuration and all corresponding variables will be applied,  but they are now deprecated in favor of the new one.

Tested scenarios:

| Test  | Outcome |
|--------|---------------|
| `serviceinfo_api_server_config` is not set, a custom `serviceinfo_api_server_service_info_initial_user_sshkeys` is given | serviceinfo-api-server successfully starts with the default configuration and specified SSH key | 
| `serviceinfo_api_server_config` is set inline | serviceinfo-api-server successfully starts with the custom configuration |
| `serviceinfo_api_server_config` is passed as a static file | serviceinfo-api-server successfully starts with the custom configuration |
| `serviceinfo_api_server_config` is passed as a template | serviceinfo-api-server successfully starts with the custom configuration |
