### PR TITLE
Deprecating setup_aio_server and configure_aio_server roles

### DIFF
--- a/meta/runtime.yaml
+++ b/meta/runtime.yaml
@@ -1,0 +1,12 @@
+---
+requires_ansible: ">=2.15.4"
+namespace: community
+name: fdo
+
+dependencies: {}
+
+deprecated_roles:
+- name: configure_aio_server
+  removal_date: "2025-12-31"
+- name: setup_aio_server
+  removal_date: "2025-12-31"

--- a/roles/configure_aio_server/tasks/main.yml
+++ b/roles/configure_aio_server/tasks/main.yml
@@ -2,6 +2,13 @@
 # Copyright: (c) 2022, XLAB Steampunk <steampunk@xlab.si>
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+# Show a Deprecation warning message
+- name: Deprecation warning
+  fail:
+    msg: "Warning!!! configure_aio_server role is deprecated"
+  when: ansible_check_mode == false
+  ignore_errors: true
+
 - name: Update config files and restart FDO AIO service
   block:
     - name: Create backups of old config files and create new ones from templates

--- a/roles/configure_aio_server/tasks/main.yml
+++ b/roles/configure_aio_server/tasks/main.yml
@@ -6,8 +6,8 @@
 - name: Deprecation warning
   fail:
     msg: "Warning!!! configure_aio_server role is deprecated"
-  when: ansible_check_mode == false
-  ignore_errors: true
+  when: not ansible_check_mode
+  failed_when: false
 
 - name: Update config files and restart FDO AIO service
   block:

--- a/roles/setup_aio_server/tasks/main.yaml
+++ b/roles/setup_aio_server/tasks/main.yaml
@@ -2,6 +2,13 @@
 # Copyright: (c) 2022, XLAB Steampunk <steampunk@xlab.si>
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+# Show a Deprecation warning message
+- name: Deprecation warning
+  fail:
+    msg: "Warning!!! setup_aio_server role is deprecated"
+  when: ansible_check_mode == false
+  ignore_errors: true
+
 - name: Install Packages
   ansible.builtin.dnf:
     state: present

--- a/roles/setup_aio_server/tasks/main.yaml
+++ b/roles/setup_aio_server/tasks/main.yaml
@@ -6,8 +6,8 @@
 - name: Deprecation warning
   fail:
     msg: "Warning!!! setup_aio_server role is deprecated"
-  when: ansible_check_mode == false
-  ignore_errors: true
+  when: not ansible_check_mode
+  failed_when: false
 
 - name: Install Packages
   ansible.builtin.dnf:


### PR DESCRIPTION
Added meta/runtime.yaml file to mark setup_aio_server and configure_aio_server roles as deprecated. Additionally added a deprecation warning message to setup_aio_server and configure_aio_server roles.

#27 